### PR TITLE
[feat] 게시글 좋아요 기능 구현

### DIFF
--- a/src/main/java/com/sparta/newsfeedteamproject/controller/LikeController.java
+++ b/src/main/java/com/sparta/newsfeedteamproject/controller/LikeController.java
@@ -1,7 +1,16 @@
 package com.sparta.newsfeedteamproject.controller;
 
+import com.sparta.newsfeedteamproject.dto.BaseResDto;
+import com.sparta.newsfeedteamproject.dto.LikeResDto;
+import com.sparta.newsfeedteamproject.security.UserDetailsImpl;
 import com.sparta.newsfeedteamproject.service.LikeService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -11,4 +20,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class LikeController {
 
     private final LikeService likeService;
+
+    @PostMapping("/{feedId}/like")
+    public ResponseEntity<BaseResDto<LikeResDto>> likeFeed(@PathVariable("feedId") @Valid Long feedId, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        BaseResDto<LikeResDto> response = likeService.likeFeed(feedId,userDetails);
+        return new ResponseEntity<>(response,HttpStatus.OK);
+    }
 }

--- a/src/main/java/com/sparta/newsfeedteamproject/dto/LikeResDto.java
+++ b/src/main/java/com/sparta/newsfeedteamproject/dto/LikeResDto.java
@@ -1,4 +1,18 @@
 package com.sparta.newsfeedteamproject.dto;
 
+import com.sparta.newsfeedteamproject.entity.Contents;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
 public class LikeResDto {
+
+    private Long contentsId;
+    private Contents contentsType;
+
+    public LikeResDto(Long contentsId, Contents contents) {
+        this.contentsId = contentsId;
+        this.contentsType = contents;
+    }
 }

--- a/src/main/java/com/sparta/newsfeedteamproject/entity/Like.java
+++ b/src/main/java/com/sparta/newsfeedteamproject/entity/Like.java
@@ -2,12 +2,14 @@ package com.sparta.newsfeedteamproject.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
 @Getter
 @Setter
 @Table(name="like")
+@NoArgsConstructor
 public class Like extends Timestamp{
 
     @Id
@@ -21,4 +23,10 @@ public class Like extends Timestamp{
     private Contents contents;
     @Column(nullable = false, name = "contents_id")
     private Long contentsId;
+
+    public Like(User user, Long contentsId, Contents contents) {
+        this.user = user;
+        this.contents = contents;
+        this.contentsId = contentsId;
+    }
 }

--- a/src/main/java/com/sparta/newsfeedteamproject/repository/LikeRepository.java
+++ b/src/main/java/com/sparta/newsfeedteamproject/repository/LikeRepository.java
@@ -1,9 +1,16 @@
 package com.sparta.newsfeedteamproject.repository;
 
+import com.sparta.newsfeedteamproject.entity.Contents;
 import com.sparta.newsfeedteamproject.entity.Like;
+import com.sparta.newsfeedteamproject.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+import java.util.Optional;
+
 @Repository
 public interface LikeRepository extends JpaRepository<Like, Long> {
+    Optional<Like> findByContentsIdAndContentsAndUser(Long contentId, Contents contents, User user);
+    Optional<List<Like>> findAllByContentsIdAndContents(Long contentId, Contents contents);
 }

--- a/src/main/java/com/sparta/newsfeedteamproject/service/LikeService.java
+++ b/src/main/java/com/sparta/newsfeedteamproject/service/LikeService.java
@@ -1,11 +1,62 @@
 package com.sparta.newsfeedteamproject.service;
 
+import com.sparta.newsfeedteamproject.dto.BaseResDto;
+import com.sparta.newsfeedteamproject.dto.LikeResDto;
+import com.sparta.newsfeedteamproject.entity.Contents;
+import com.sparta.newsfeedteamproject.entity.Like;
+import com.sparta.newsfeedteamproject.entity.User;
 import com.sparta.newsfeedteamproject.repository.LikeRepository;
+import com.sparta.newsfeedteamproject.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
 public class LikeService {
     private final LikeRepository likeRepository;
+    private final FeedService feedService;
+
+    public BaseResDto<LikeResDto> likeFeed(Long feedId, UserDetailsImpl userDetails) {
+        User user = userDetails.getUser();
+        Optional<Like> like = likeRepository.findByContentsIdAndContentsAndUser(feedId, Contents.FEED, user);
+        LikeResDto likeResDto = new LikeResDto(feedId, Contents.FEED);
+
+        if (like.isEmpty()) { //좋아요 등록
+            Like newlike = new Like(user, feedId, Contents.FEED);
+            likeRepository.save(newlike);
+
+            //게시물 DB에 저장된 좋아요 수 +1
+            feedService.increaseFeedLikes(feedId); //FeedSerivce에 구현되어야함
+
+            return new BaseResDto(HttpStatus.OK.value(), "게시글을 좋아요하였습니다!", likeResDto);
+
+        } else {//좋아요 취소
+            Like oldLike = like.orElseThrow(
+                    () -> new IllegalArgumentException("해당 요소가 없습니다.")
+            );
+            likeRepository.delete(oldLike);
+
+            //게시물 DB에 저장된 좋아요 수 -1
+            feedService.decreaseFeedLikes(feedId); //FeedSerivce에 구현되어야함
+            return new BaseResDto(HttpStatus.OK.value(), "게시글 좋아요를 취소하였습니다!", likeResDto);
+        }
+    }
+
+    //게시글 or 댓글 삭제 시 해당 게시글 or 댓글의 좋아요를 모두 삭제하는 메서드
+    public void deleteAllLikes(Long contentsId, Contents contentType){
+         likeRepository.findAllByContentsIdAndContents(contentsId, contentType)
+                 .ifPresent(likes -> likes.stream()
+                         .forEach(like -> likeRepository.delete(like)));
+    }
+
+    //게시글 삭제 시 해당 게시글의 댓글들의 좋아요를 모두 삭제하는 메서드
+    public void deleteAllCommentsLikes(List<Long> contentsIds, Contents contentType){
+        contentsIds.stream()
+                .forEach(id -> deleteAllLikes(id, contentType));
+    }
+
 }


### PR DESCRIPTION
-게시글 좋아요 요청시 기능 구현 완료 (이미 좋아요 된 상태면 좋아요 취소)
-게시글 or 댓글 삭제 시 해당 게시글 or 댓글의 좋아요를 모두 삭제하는 메서드 추가
-게시글 삭제 시 해당 게시글의 댓글들의 좋아요를 모두 삭제하는 메서드 추가